### PR TITLE
Remove version number from galaxy.yaml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: netconf
 namespace: network
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.network.netconf
-version: 0.0.1


### PR DESCRIPTION
This isn't needed now that we dynamically generate our version numbers
from git info.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>